### PR TITLE
Make the occupancy map a parameter

### DIFF
--- a/src/gmrf_node.cpp
+++ b/src/gmrf_node.cpp
@@ -29,6 +29,7 @@ Cgmrf::Cgmrf()
     //------------------
     ros::NodeHandle param_n("~");
     param_n.param<std::string>("frame_id", frame_id, "/map");
+    param_n.param<std::string>("ocupancy_map", ocupancy_map, "/map");
     param_n.param<std::string>("sensor_topic", sensor_topic, "/Mox01/Sensor_reading");
     param_n.param<double>("exec_freq", exec_freq, 2.0 );
     param_n.param<double>("cell_size", cell_size, 0.5);
@@ -51,7 +52,7 @@ Cgmrf::Cgmrf()
     // Subscriptions
     //----------------------------------
     sub_sensor = param_n.subscribe(sensor_topic, 1, &Cgmrf::sensorCallback, this);
-    ocupancyMap_sub = param_n.subscribe("/map", 1, &Cgmrf::mapCallback, this);
+    ocupancyMap_sub = param_n.subscribe(ocupancy_map, 1, &Cgmrf::mapCallback, this);
     //----------------------------------
     // Publishers
     //----------------------------------

--- a/src/gmrf_node.cpp
+++ b/src/gmrf_node.cpp
@@ -29,7 +29,7 @@ Cgmrf::Cgmrf()
     //------------------
     ros::NodeHandle param_n("~");
     param_n.param<std::string>("frame_id", frame_id, "/map");
-    param_n.param<std::string>("ocupancy_map", ocupancy_map, "/map");
+    param_n.param<std::string>("occupancy_map", occupancy_map, "/map");
     param_n.param<std::string>("sensor_topic", sensor_topic, "/Mox01/Sensor_reading");
     param_n.param<double>("exec_freq", exec_freq, 2.0 );
     param_n.param<double>("cell_size", cell_size, 0.5);
@@ -52,7 +52,7 @@ Cgmrf::Cgmrf()
     // Subscriptions
     //----------------------------------
     sub_sensor = param_n.subscribe(sensor_topic, 1, &Cgmrf::sensorCallback, this);
-    ocupancyMap_sub = param_n.subscribe(ocupancy_map, 1, &Cgmrf::mapCallback, this);
+    occupancyMap_sub = param_n.subscribe(occupancy_map, 1, &Cgmrf::mapCallback, this);
     //----------------------------------
     // Publishers
     //----------------------------------

--- a/src/gmrf_node.cpp
+++ b/src/gmrf_node.cpp
@@ -29,7 +29,7 @@ Cgmrf::Cgmrf()
     //------------------
     ros::NodeHandle param_n("~");
     param_n.param<std::string>("frame_id", frame_id, "/map");
-    param_n.param<std::string>("occupancy_map", occupancy_map, "/map");
+    param_n.param<std::string>("occupancy_map_topic", occupancy_map_topic, "/map");
     param_n.param<std::string>("sensor_topic", sensor_topic, "/Mox01/Sensor_reading");
     param_n.param<double>("exec_freq", exec_freq, 2.0 );
     param_n.param<double>("cell_size", cell_size, 0.5);
@@ -52,7 +52,7 @@ Cgmrf::Cgmrf()
     // Subscriptions
     //----------------------------------
     sub_sensor = param_n.subscribe(sensor_topic, 1, &Cgmrf::sensorCallback, this);
-    occupancyMap_sub = param_n.subscribe(occupancy_map, 1, &Cgmrf::mapCallback, this);
+    occupancyMap_sub = param_n.subscribe(occupancy_map_topic, 1, &Cgmrf::mapCallback, this);
     //----------------------------------
     // Publishers
     //----------------------------------

--- a/src/gmrf_node.h
+++ b/src/gmrf_node.h
@@ -69,7 +69,7 @@ public:
     //Node Params
     std::string                             sensor_topic;
     std::string                             frame_id;
-    std::string                             occupancy_map;
+    std::string                             occupancy_map_topic;
     double                                  cell_size;
     double                                  exec_freq;
     std::string                             colormap;

--- a/src/gmrf_node.h
+++ b/src/gmrf_node.h
@@ -69,6 +69,7 @@ public:
     //Node Params
     std::string                             sensor_topic;
     std::string                             frame_id;
+    std::string                             ocupancy_map;
     double                                  cell_size;
     double                                  exec_freq;
     std::string                             colormap;

--- a/src/gmrf_node.h
+++ b/src/gmrf_node.h
@@ -69,7 +69,7 @@ public:
     //Node Params
     std::string                             sensor_topic;
     std::string                             frame_id;
-    std::string                             ocupancy_map;
+    std::string                             occupancy_map;
     double                                  cell_size;
     double                                  exec_freq;
     std::string                             colormap;
@@ -99,7 +99,7 @@ protected:
     tf::TransformListener                   tf_listener; //Do not put inside the callback
 
     //Subscriptions & Publishers
-    ros::Subscriber sub_sensor, ocupancyMap_sub;
+    ros::Subscriber sub_sensor, occupancyMap_sub;
     ros::Publisher mean_advertise, var_advertise;
 
     //Callbacks


### PR DESCRIPTION
I need to run a map server with a non-standard name (i.e. not called "map"). This modification enables the user to specify a different occupancy map topic 